### PR TITLE
feat: upgrade to jekyll 4

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,4 +1,4 @@
-name: Deploy Jekyll to GHPages
+name: Deploy to GitHub Pages
 
 on:
   push:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,21 @@
+name: Deploy Jekyll to GHPages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  github-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - uses: helaili/jekyll-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/_pages/software-crafting/static-websites/jekyll.md
+++ b/_pages/software-crafting/static-websites/jekyll.md
@@ -91,6 +91,10 @@ and re-install your Ruby gems
 $ bundle install
 ```
 
+#### Publishing to GitHub Pages
+
+Please refer to the [jekyll: GitHub Actions](https://jekyllrb.com/docs/continuous-integration/github-actions/) guide for setting up the latest jekyll version with GitHub pages.
+
 #### Authentication and Restricted Access
 
 The [jekyll-auth](https://github.com/benbalter/jekyll-auth) module allows to restrict access. It uses GitHub OAuth and allows to manage user access via GitHub organizations and teams.


### PR DESCRIPTION
GitHub pages only support jekyll 3.9.0. In that version, csv support requires going back to ruby 2.

In order to use the latest jekyll version and ruby 3 I have decided to deactivate the automatically generated GitHub pages
and switch over to using a GitHub action to build the site.

See: https://jekyllrb.com/docs/continuous-integration/github-actions/